### PR TITLE
Fix opening invalid pull request when branch name is number

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func GetNewPrUrl(repository string, branch string) string {
 func GetPrUrl(repository string, branch string) string {
 	branchOrNumber := ""
 
-	if isNumber(branch) {
+	if IsNumberString(branch) {
 		repo := strings.Replace(repository, "https://github.com/", "", 1)
 		repoQuery := fmt.Sprintf("--repo=%s", repo)
 		headQuery := fmt.Sprintf("--head=%s", branch)
@@ -97,7 +97,7 @@ func GetPrUrl(repository string, branch string) string {
 	return prUrl
 }
 
-func isNumber(value string) bool {
+func IsNumberString(value string) bool {
 	if _, err := strconv.Atoi(value); err == nil {
 		return true
 	}

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/cli/go-gh/v2"
@@ -48,11 +50,57 @@ func getRepositoryUrl() string {
 	return strings.TrimSuffix(stdOut.String(), "\n")
 }
 
+func GetNewPrUrl(repository string, branch string) string {
+	prUrl, err := url.JoinPath(repository, "compare", branch)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	parsedUrl, err := url.Parse(prUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	queries := parsedUrl.Query()
+	queries.Add("expand", "1")
+	parsedUrl.RawQuery = queries.Encode()
+	return parsedUrl.String()
+}
+
 func GetPrUrl(repository string, branch string) string {
-	prUrl, err := url.JoinPath(repository, "pull", branch)
+	branchOrNumber := ""
+
+	if isNumber(branch) {
+		repo := strings.Replace(repository, "https://github.com/", "", 1)
+		repoQuery := fmt.Sprintf("--repo=%s", repo)
+		headQuery := fmt.Sprintf("--head=%s", branch)
+		searchedPrNumber, _, err := gh.Exec("search", "prs", repoQuery, headQuery, "--json=number", "-q=.[].number")
+		if err != nil {
+			return GetNewPrUrl(repository, branch)
+		}
+
+		prNumber := strings.TrimSuffix(searchedPrNumber.String(), "\n")
+		if prNumber == "" {
+			return GetNewPrUrl(repository, branch)
+		} else {
+			branchOrNumber = prNumber
+		}
+	} else {
+		branchOrNumber = branch
+	}
+
+	prUrl, err := url.JoinPath(repository, "pull", branchOrNumber)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	return prUrl
+}
+
+func isNumber(value string) bool {
+	if _, err := strconv.Atoi(value); err == nil {
+		return true
+	}
+
+	return false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -15,3 +15,18 @@ func TestGetPrUrl(t *testing.T) {
 
 	assert.Equal(t, expected, actual)
 }
+
+func TestGetNewPrUrl(t *testing.T) {
+	assert.Equal(t,
+		"https://github.com/kyoshidajp/gh-browse-pr/compare/test?expand=1",
+		GetNewPrUrl("https://github.com/kyoshidajp/gh-browse-pr", "test"),
+	)
+}
+
+func TestIsNumberString(t *testing.T) {
+	assert.Equal(t, true, IsNumberString("100"))
+	assert.Equal(t, true, IsNumberString("001"))
+	assert.Equal(t, true, IsNumberString("-1")) // allow
+	assert.Equal(t, false, IsNumberString("test"))
+	assert.Equal(t, false, IsNumberString("1test"))
+}


### PR DESCRIPTION

| branch name | PR number | before path | expected path | invalid path |
| ------ | ----- | --- | --- | :---: |
| 100 | 5 | `/pull/100` | `/pull/5` | ✅  |
| 200 | (not exists) | `/pull/200` | `/compare/200?expand=1` | ✅  |
| hoge | 6 | `/pull/6` | `/pull/6` | |
| test | (not exists) | `/compare/test?expand=1` | `/compare/test?expand=1` | |