### PR TITLE
Don't open invalid URL

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,11 @@ func Execute() {
 	repositoryURL := getRepositoryURL()
 	prURL := GetPrURL(repositoryURL, currentBranch)
 
+	if !strings.HasPrefix(prURL, GitHubURL) {
+		message := fmt.Sprintf("Can't open URL: %s", prURL)
+		log.Fatal(message)
+	}
+
 	browser.OpenURL(prURL)
 }
 


### PR DESCRIPTION
Opening URL is must be started with `https://github.com`.